### PR TITLE
feat(project): add priority field to projects with UI and DB support

### DIFF
--- a/apps/nextjs/src/app/dashboard/page.tsx
+++ b/apps/nextjs/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import { ChangeBadgeVariantInput } from '~/calendar/components/change-badge-variant-input'
 import { ClientContainer } from '~/calendar/components/client-container'
-import { CalendarProvider, useCalendar } from '~/calendar/contexts/calendar-context'
+import { useCalendar } from '~/calendar/contexts/calendar-context'
 
 const page = () => {
     const { view } = useCalendar();

--- a/apps/nextjs/src/app/enact/projects/page.tsx
+++ b/apps/nextjs/src/app/enact/projects/page.tsx
@@ -65,7 +65,7 @@ import { ProjectCard } from "~/app/_components/project-card";
 import { DatePickerWithInput } from "~/components/ui/datepicker-with-input";
 import { Textarea } from "~/components/ui/textarea";
 
-type Project = RouterOutputs["project"]["getAll"][number];
+type Project = RouterOutputs["project"]["getAll"][number] & { priority?: string };
 
 // Node types for the mini process preview
 const nodeTypes = {
@@ -90,7 +90,7 @@ export default function ProjectsPage() {
       setIsModalOpen(false);
       setDialogStep(1);
       setSelectedProcessId(null);
-      setProjectMetadata({ name: "", description: "" });
+      setProjectMetadata({ name: "", description: "", priority: "Medium" });
     },
   }));
   const process = useQuery(trpc.process.getAll.queryOptions());
@@ -98,7 +98,7 @@ export default function ProjectsPage() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedProcessId, setSelectedProcessId] = useState<string | null>(null);
   const [dialogStep, setDialogStep] = useState(1);
-  const [projectMetadata, setProjectMetadata] = useState({ name: "", description: "" });
+  const [projectMetadata, setProjectMetadata] = useState({ name: "", description: "", priority: "Medium" });
   const [taskAssignments, setTaskAssignments] = useState<Record<string, string>>({});
   const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
 
@@ -116,7 +116,7 @@ export default function ProjectsPage() {
     if (!isModalOpen) {
       setDialogStep(1);
       setSelectedProcessId(null);
-      setProjectMetadata({ name: "", description: "" });
+      setProjectMetadata({ name: "", description: "", priority: "Medium" });
       setTaskAssignments({});
       setExpandedTasks(new Set());
     }
@@ -148,6 +148,7 @@ export default function ProjectsPage() {
         processId: selectedProcessId,
         name: projectMetadata.name,
         description: projectMetadata.description,
+        priority: projectMetadata.priority,
       });
     }
   };
@@ -251,6 +252,42 @@ export default function ProjectsPage() {
 
                   <div>
                     <DatePickerWithInput label="Project Start Date" />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="project-priority">Priority</Label>
+                    <Select
+                      value={projectMetadata.priority}
+                      onValueChange={val => setProjectMetadata(prev => ({ ...prev, priority: val }))}
+                    >
+                      <SelectTrigger className="w-full mt-2">
+                        <SelectValue placeholder="Select priority" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Critical">
+                          <span className="inline-block w-2 h-2 rounded-full bg-purple-600 mr-2 align-middle" />
+                          Critical
+                        </SelectItem>
+                        <SelectItem value="High">
+                          <span className="inline-block w-2 h-2 rounded-full bg-red-500 mr-2 align-middle" />
+                          High
+                        </SelectItem>
+
+                        <SelectItem value="Medium">
+                          <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 mr-2 align-middle" />
+                          Medium
+                        </SelectItem>
+                        <SelectItem value="Low">
+                          <span className="inline-block w-2 h-2 rounded-full bg-green-500 mr-2 align-middle" />
+                          Low
+                        </SelectItem>
+
+                        <SelectItem value="Lowest">
+                          <span className="inline-block w-2 h-2 rounded-full bg-gray-400 mr-2 align-middle" />
+                          Lowest
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div>

--- a/packages/api/src/router/project.ts
+++ b/packages/api/src/router/project.ts
@@ -33,6 +33,7 @@ export const projectRouter = {
       processId: z.string(),
       name: z.string().optional(),
       description: z.string().optional(),
+      priority: z.enum(["Lowest", "Low", "Medium", "High", "Critical"]).optional(),
     }))
     .mutation(async ({ input, ctx }) => {
       const process = await ctx.db.query.Process.findFirst({
@@ -47,6 +48,7 @@ export const projectRouter = {
         description: input.description || process.description,
         flowData: process.flowData,
         status: "ACTIVE",
+        priority: input.priority || "Medium",
         createdAt: new Date(),
         updatedAt: new Date(),
       }).returning();

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -66,6 +66,13 @@ export const Node = pgTable("node", (t) => ({
     .$onUpdateFn(() => sql`now()`),
 }));
 
+export const projectPriorityEnum = pgEnum("ProjectPriority", [
+  "Lowest",
+  "Low",
+  "Medium",
+  "High",
+  "Critical",
+]);
 
 export const Project = pgTable("project", (t) => ({
   id: t.uuid().defaultRandom().primaryKey(),
@@ -73,6 +80,7 @@ export const Project = pgTable("project", (t) => ({
   description: t.text(),
   status: processStatusEnum("status").notNull(),
   flowData: t.json().notNull(),
+  priority: projectPriorityEnum("priority").notNull().default("Medium"),
   createdAt: t
     .timestamp({ mode: "date", withTimezone: true })
     .defaultNow()


### PR DESCRIPTION
Add a priority attribute to the project model with defined enum values
(Lowest, Low, Medium, High, Critical) and set the default to Medium. Update
the database schema to include the priority column with a default value.

Enhance the project creation and editing UI to allow users to select a
priority via a dropdown with color-coded options. Initialize the priority
state to Medium to ensure consistent default behavior.

These changes improve project management by enabling priority tracking and
better task organization.