### PR TITLE
refactor: rename project to process in ProcessCard component

### DIFF
--- a/apps/nextjs/src/app/_components/priority.tsx
+++ b/apps/nextjs/src/app/_components/priority.tsx
@@ -1,0 +1,38 @@
+import { projectPriorityEnum } from '@acme/db/schema';
+import React from 'react'
+import { Badge } from '~/components/ui/badge';
+import { SelectItem } from '~/components/ui/select';
+import { cn } from '~/lib/utils';
+
+export const priorities = projectPriorityEnum.enumValues;
+export const priorityColorMap: Record<(typeof projectPriorityEnum.enumValues)[number], string> = {
+    Lowest: "bg-gray-400",
+    Low: "bg-green-600",
+    Medium: "bg-yellow-600",
+    High: "bg-red-600",
+    Critical: "bg-purple-800",
+};
+
+export const PriorityBadge = ({ priority }: { priority: (typeof projectPriorityEnum.enumValues)[number] }) => {
+    return (
+        <Badge
+            className={cn(`text-xs flex items-center gap-1`, priorityColorMap[priority], priority === "Lowest" ? "text-gray-900" : "text-white")}
+        >
+            {priority}
+        </Badge>
+    )
+}
+
+export const PrioritySelectOptions = ({ reverse = false }: { reverse?: boolean }) => {
+    const items = reverse ? [...priorities].reverse() : priorities;
+    return (
+        <>
+            {items.map(priority => (
+                <SelectItem key={priority} value={priority}>
+                    <span className={cn(`inline-block w-2 h-2 rounded-full mr-2 align-middle`, priorityColorMap[priority])} />
+                    {priority}
+                </SelectItem>
+            ))}
+        </>
+    )
+}

--- a/apps/nextjs/src/app/_components/process-card.tsx
+++ b/apps/nextjs/src/app/_components/process-card.tsx
@@ -30,26 +30,26 @@ const nodeTypes = {
 };
 
 export function ProcessCard({
-    project,
+    process,
     isPreview = false,
 }: {
-    project: RouterOutputs["process"]["getAll"][number];
+    process: RouterOutputs["process"]["getAll"][number];
     isPreview?: boolean;
 }) {
     const queryClient = useQueryClient();
     const trpc = useTRPC();
 
     const { theme } = useTheme();
-    const flowData = project.flowData as { nodes?: Node[]; edges?: Edge[] };
+    const flowData = process.flowData as { nodes?: Node[]; edges?: Edge[] };
     const nodes = flowData.nodes ?? [];
     const edges = flowData.edges ?? [];
     const overview = getProcessOverview({
-        name: project.name,
-        description: project.description,
+        name: process.name,
+        description: process.description,
         nodes,
         edges,
-        createdAt: project.createdAt.toISOString(),
-        updatedAt: project.updatedAt.toISOString(),
+        createdAt: process.createdAt.toISOString(),
+        updatedAt: process.updatedAt.toISOString(),
     });
     const formatDate = (dateString: string) => {
         return new Date(dateString).toLocaleDateString("en-US", {
@@ -65,26 +65,15 @@ export function ProcessCard({
             <CardHeader>
                 <div className="flex items-start justify-between">
                     <div className="flex-1">
-                        <CardTitle className="text-lg">{project.name}</CardTitle>
+                        <CardTitle className="text-lg">{process.name}</CardTitle>
                         <p className="text-muted-foreground mt-1 text-sm">
-                            {project.description ?? "No description provided"}
+                            {process.description ?? "No description provided"}
                         </p>
                     </div>
-                    <Badge
-                        variant={
-                            overview.complexity === "High"
-                                ? "destructive"
-                                : overview.complexity === "Medium"
-                                    ? "default"
-                                    : "secondary"
-                        }
-                    >
-                        {overview.complexity}
-                    </Badge>
                 </div>
             </CardHeader>
             <CardContent className="space-y-4">
-                {/* Project Overview */}
+                {/* process Overview */}
                 <div className="space-y-3">
                     <div className="flex items-center justify-between text-sm">
                         <span className="text-muted-foreground">Nodes:</span>
@@ -112,7 +101,7 @@ export function ProcessCard({
                 </div>
                 {/* XYFlow Data Preview */}
                 <div className="space-y-2">
-                    <Label className="text-sm font-medium">Project Preview</Label>
+                    <Label className="text-sm font-medium">Process Preview</Label>
                     <div className="h-48 overflow-hidden rounded-md border">
                         <ReactFlow
                             className={theme === "dark" ? "dark" : ""}
@@ -157,26 +146,26 @@ export function ProcessCard({
                 <div className="text-muted-foreground space-y-2 text-xs">
                     <div className="flex items-center space-x-2">
                         <Calendar className="h-3 w-3" />
-                        <span>Created: {formatDate(project.createdAt.toISOString())}</span>
+                        <span>Created: {formatDate(process.createdAt.toISOString())}</span>
                     </div>
                     <div className="flex items-center space-x-2">
                         <Calendar className="h-3 w-3" />
-                        <span>Updated: {formatDate(project.updatedAt.toISOString())}</span>
+                        <span>Updated: {formatDate(process.updatedAt.toISOString())}</span>
                     </div>
                 </div>
                 {/* Actions */}
                 {!isPreview && (
                     <div className="flex items-center space-x-2 pt-2">
                         <Link
-                            href={`/plan/process-designer?project=${encodeURIComponent(project.id)}`}
+                            href={`/plan/process-designer?process=${encodeURIComponent(process.id)}`}
                             onMouseEnter={() => {
                                 void queryClient.prefetchQuery(
-                                    trpc.process.getById.queryOptions({ id: project.id }),
+                                    trpc.process.getById.queryOptions({ id: process.id }),
                                 );
                             }}
                             onFocus={() => {
                                 void queryClient.prefetchQuery(
-                                    trpc.process.getById.queryOptions({ id: project.id }),
+                                    trpc.process.getById.queryOptions({ id: process.id }),
                                 );
                             }}
                         >

--- a/apps/nextjs/src/app/_components/project-card.tsx
+++ b/apps/nextjs/src/app/_components/project-card.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { Background, ReactFlow } from "@xyflow/react";
 import { Calendar, Edit, Eye, Loader2, Share2, Trash2 } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
@@ -19,6 +18,9 @@ import {
 } from "./flow-designer/nodes";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "~/trpc/react";
+import "@xyflow/react/dist/style.css";
+import { PriorityBadge } from "./priority";
+
 
 const nodeTypes = {
     start: StartNode,
@@ -76,17 +78,7 @@ export function ProjectCard({
                             {project.description ?? "No description provided"}
                         </p>
                     </div>
-                    <Badge
-                        variant={
-                            overview.complexity === "High"
-                                ? "destructive"
-                                : overview.complexity === "Medium"
-                                    ? "default"
-                                    : "secondary"
-                        }
-                    >
-                        {overview.complexity}
-                    </Badge>
+                    <PriorityBadge priority={project.priority} />
                 </div>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/apps/nextjs/src/app/enact/projects/page.tsx
+++ b/apps/nextjs/src/app/enact/projects/page.tsx
@@ -1,32 +1,20 @@
 "use client";
 
-import type { Edge, Node } from "@xyflow/react";
-import { useEffect, useState, useRef } from "react";
-import Link from "next/link";
-import { Background, ReactFlow } from "@xyflow/react";
+import { useEffect, useState } from "react";
 import {
-  Calendar,
-  Database,
-  Edit,
-  Eye,
   FileText,
   Plus,
   Search,
-  Share2,
-  Trash2,
   ChevronDown,
   ChevronRight,
   Clock,
   User,
   Tag,
 } from "lucide-react";
-import { useTheme } from "next-themes";
 
-import type { ProcessData } from "~/app/lib/process-utils";
-import { getProcessOverview } from "~/app/lib/process-utils";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Card } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import {
@@ -45,7 +33,6 @@ import {
   DialogClose,
 } from "~/components/ui/dialog";
 
-import "@xyflow/react/dist/style.css";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -64,8 +51,9 @@ import { ProcessCard } from "~/app/_components/process-card";
 import { ProjectCard } from "~/app/_components/project-card";
 import { DatePickerWithInput } from "~/components/ui/datepicker-with-input";
 import { Textarea } from "~/components/ui/textarea";
+import { PrioritySelectOptions } from "~/app/_components/priority";
 
-type Project = RouterOutputs["project"]["getAll"][number] & { priority?: string };
+type Project = RouterOutputs["project"]["getAll"][number]
 
 // Node types for the mini process preview
 const nodeTypes = {
@@ -98,7 +86,7 @@ export default function ProjectsPage() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedProcessId, setSelectedProcessId] = useState<string | null>(null);
   const [dialogStep, setDialogStep] = useState(1);
-  const [projectMetadata, setProjectMetadata] = useState({ name: "", description: "", priority: "Medium" });
+  const [projectMetadata, setProjectMetadata] = useState({ name: "", description: "", priority: "Medium" as "Lowest" | "Low" | "Medium" | "High" | "Critical" });
   const [taskAssignments, setTaskAssignments] = useState<Record<string, string>>({});
   const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
 
@@ -124,22 +112,12 @@ export default function ProjectsPage() {
 
   const handleNextStep = () => {
     if (selectedProcessId) {
-      setDialogStep(2);
+      setDialogStep((step) => step + 1);
     }
   };
 
   const handleBackStep = () => {
-    setDialogStep(1);
-  };
-
-  const handleNextToAssignments = () => {
-    if (projectMetadata.name.trim()) {
-      setDialogStep(3);
-    }
-  };
-
-  const handleBackToMetadata = () => {
-    setDialogStep(2);
+    setDialogStep((step) => step - 1);
   };
 
   const handleCreateProject = () => {
@@ -227,7 +205,7 @@ export default function ProjectsPage() {
                           <Label>Process Preview</Label>
                           <div className="mt-2">
                             <ProcessCard
-                              project={process.data?.find(p => p.id === selectedProcessId)!}
+                              process={process.data?.find(p => p.id === selectedProcessId)!}
                               isPreview
                             />
                           </div>
@@ -258,34 +236,13 @@ export default function ProjectsPage() {
                     <Label htmlFor="project-priority">Priority</Label>
                     <Select
                       value={projectMetadata.priority}
-                      onValueChange={val => setProjectMetadata(prev => ({ ...prev, priority: val }))}
+                      onValueChange={val => setProjectMetadata(prev => ({ ...prev, priority: val as "Lowest" | "Low" | "Medium" | "High" | "Critical" }))}
                     >
                       <SelectTrigger className="w-full mt-2">
                         <SelectValue placeholder="Select priority" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="Critical">
-                          <span className="inline-block w-2 h-2 rounded-full bg-purple-600 mr-2 align-middle" />
-                          Critical
-                        </SelectItem>
-                        <SelectItem value="High">
-                          <span className="inline-block w-2 h-2 rounded-full bg-red-500 mr-2 align-middle" />
-                          High
-                        </SelectItem>
-
-                        <SelectItem value="Medium">
-                          <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 mr-2 align-middle" />
-                          Medium
-                        </SelectItem>
-                        <SelectItem value="Low">
-                          <span className="inline-block w-2 h-2 rounded-full bg-green-500 mr-2 align-middle" />
-                          Low
-                        </SelectItem>
-
-                        <SelectItem value="Lowest">
-                          <span className="inline-block w-2 h-2 rounded-full bg-gray-400 mr-2 align-middle" />
-                          Lowest
-                        </SelectItem>
+                        <PrioritySelectOptions reverse={true} />
                       </SelectContent>
                     </Select>
                   </div>
@@ -459,7 +416,7 @@ export default function ProjectsPage() {
                       Back
                     </Button>
                     <Button
-                      onClick={handleNextToAssignments}
+                      onClick={handleNextStep}
                       disabled={!projectMetadata.name.trim()}
                     >
                       Next
@@ -467,7 +424,7 @@ export default function ProjectsPage() {
                   </>
                 ) : (
                   <>
-                    <Button variant="outline" onClick={handleBackToMetadata}>
+                    <Button variant="outline" onClick={handleBackStep}>
                       Back
                     </Button>
                     <Button

--- a/apps/nextjs/src/app/plan/processes/page.tsx
+++ b/apps/nextjs/src/app/plan/processes/page.tsx
@@ -40,6 +40,7 @@ import {
   StartNode,
 } from "~/app/_components/flow-designer/nodes";
 import { useTRPC } from "~/trpc/react";
+import { ProcessCard } from "~/app/_components/process-card";
 
 type Process = RouterOutputs["process"]["getAll"][number];
 
@@ -374,169 +375,10 @@ export default function ProcessesPage() {
             });
 
             return (
-              <Card className="transition-shadow hover:shadow-lg" key={index}>
-                <CardHeader>
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1">
-                      <CardTitle className="text-lg">{process.name}</CardTitle>
-                      <p className="text-muted-foreground mt-1 text-sm">
-                        {process.description ?? "No description provided"}
-                      </p>
-                    </div>
-                    <Badge
-                      variant={
-                        overview.complexity === "High"
-                          ? "destructive"
-                          : overview.complexity === "Medium"
-                            ? "default"
-                            : "secondary"
-                      }
-                    >
-                      {overview.complexity}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {/* Process Overview */}
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-muted-foreground">Nodes:</span>
-                      <span className="font-medium">{overview.nodeCount}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-muted-foreground">
-                        Connections:
-                      </span>
-                      <span className="font-medium">{overview.edgeCount}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-muted-foreground">Node Types:</span>
-                      <div className="flex gap-1">
-                        {overview.nodeTypes
-                          .slice(0, 3)
-                          .map((type: string, i: number) => (
-                            <Badge
-                              className="text-xs"
-                              key={i}
-                              variant="outline"
-                            >
-                              {type}
-                            </Badge>
-                          ))}
-                        {overview.nodeTypes.length > 3 && (
-                          <Badge className="text-xs" variant="outline">
-                            +{overview.nodeTypes.length - 3}
-                          </Badge>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* XYFlow Data Preview */}
-                  <div className="space-y-2">
-                    <Label className="text-sm font-medium">
-                      Process Preview
-                    </Label>
-                    <div className="h-48 overflow-hidden rounded-md border">
-                      <ReactFlow
-                        className={theme === "dark" ? "dark" : ""}
-                        defaultEdgeOptions={{
-                          animated: true,
-                          style: { stroke: "#6366f1", strokeWidth: 2 },
-                        }}
-                        edges={edges.map((edge: Edge) => ({
-                          id: edge.id,
-                          source: edge.source,
-                          target: edge.target,
-                          type: "smoothstep",
-                          style: { stroke: "#6366f1", strokeWidth: 2 },
-                        }))}
-                        elementsSelectable={false}
-                        fitView
-                        fitViewOptions={{ padding: 0.1 }}
-                        maxZoom={1.5}
-                        minZoom={0.5}
-                        nodes={nodes.map((node: Node) => ({
-                          id: node.id,
-                          type: node.type,
-                          position: node.position,
-                          data: node.data,
-                        }))}
-                        nodesConnectable={false}
-                        nodesDraggable={false}
-                        nodeTypes={nodeTypes}
-                        panOnDrag={false}
-                        panOnScroll={false}
-                        preventScrolling={false}
-                        proOptions={{ hideAttribution: true }}
-                        zoomOnPinch={true}
-                        zoomOnScroll={true}
-                      >
-                        {/* <Controls showInteractive={false} /> */}
-                        <Background />
-                      </ReactFlow>
-                    </div>
-                  </div>
-
-                  {/* Timestamps */}
-                  <div className="text-muted-foreground space-y-2 text-xs">
-                    <div className="flex items-center space-x-2">
-                      <Calendar className="h-3 w-3" />
-                      <span>
-                        Created: {formatDate(process.createdAt.toISOString())}
-                      </span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Calendar className="h-3 w-3" />
-                      <span>
-                        Updated: {formatDate(process.updatedAt.toISOString())}
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex items-center space-x-2 pt-2">
-                    <Link
-                      href={`/plan/process-designer?process=${encodeURIComponent(process.id)}`}
-                      onMouseEnter={() => {
-                        void queryClient.prefetchQuery(
-                          trpc.process.getById.queryOptions({ id: process.id }),
-                        );
-                      }}
-                      onFocus={() => {
-                        void queryClient.prefetchQuery(
-                          trpc.process.getById.queryOptions({ id: process.id }),
-                        );
-                      }}
-                    >
-                      <Button className="flex-1" size="sm" variant="outline">
-                        <Edit className="mr-1 h-3 w-3" />
-                        Edit
-                      </Button>
-                    </Link>
-                    <Button size="sm" variant="outline">
-                      <Eye className="mr-1 h-3 w-3" />
-                      View
-                    </Button>
-                    <Button size="sm" variant="outline">
-                      <Share2 className="mr-1 h-3 w-3" />
-                      Share
-                    </Button>
-                    <Button
-                      className="text-destructive hover:text-destructive"
-                      onClick={() => {
-                        alert(
-                          "Delete functionality is not yet implemented via TRPC.",
-                        );
-                      }}
-                      size="sm"
-                      variant="outline"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
+              <ProcessCard
+                key={process.id}
+                process={process}
+              />
             );
           })}
         </div>

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -46,26 +46,6 @@ export const Process = pgTable("process", (t) => ({
     .$onUpdateFn(() => sql`now()`),
 }));
 
-export const Node = pgTable("node", (t) => ({
-  id: t.uuid().defaultRandom().primaryKey(),
-  processId: t
-    .uuid()
-    .notNull()
-    .references(() => Process.id, { onDelete: "cascade" }),
-  type: t.varchar({ length: 128 }).notNull(),
-  data: t.json().notNull(),
-  positionX: t.real(),
-  positionY: t.real(),
-  createdAt: t
-    .timestamp({ mode: "date", withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: t
-    .timestamp({ mode: "date", withTimezone: true })
-    .notNull()
-    .$onUpdateFn(() => sql`now()`),
-}));
-
 export const projectPriorityEnum = pgEnum("ProjectPriority", [
   "Lowest",
   "Low",


### PR DESCRIPTION
Remove unused Node table definition from schema.ts to clean up codebase

Update ProcessCard component to use 'process' instead of 'project'  
for clarity and consistency in naming. Adjust labels and data  
references accordingly to reflect this change.