### PR TITLE
feat(authz): Update permissions schema

### DIFF
--- a/packages/authz/package.json
+++ b/packages/authz/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "generate": "node --loader ts-node/esm script/generate-permissions.ts",
-    "test": "node --loader ts-node/esm src/index.ts"
+    "test": "node --loader ts-node/esm script/test.ts",
+    "load": "node --loader ts-node/esm script/loadSchema.ts"
   },
   "devDependencies": {
     "@acme/eslint-config": "workspace:*",

--- a/packages/authz/script/loadSchema.ts
+++ b/packages/authz/script/loadSchema.ts
@@ -1,0 +1,41 @@
+export const name = "authz";
+
+import { PermissionOperations, SpiceDBClient } from "@schoolai/spicedb-zed-schema-parser/builder";
+const SPICEDB_URL = process.env.SPICEDB_URL || 'localhost:50051';
+const SPICEDB_TOKEN = process.env.SPICEDB_TOKEN || 'localkey';
+
+import { permissions } from "../src/permissions";
+import { v1 as authzed } from "@authzed/authzed-node";
+import fs from "node:fs/promises";
+
+// Create client for local development
+const { promises: authzedClient } = authzed.NewClient(SPICEDB_TOKEN, SPICEDB_URL, 1);
+const client = authzedClient as unknown as SpiceDBClient;
+
+const op = PermissionOperations.lookup().subjectsWithAccessTo("project:1").ofType("user")
+
+
+// Function to load schema into SpiceDB
+async function loadSchema() {
+    console.log("Loading schema...");
+    try {
+        const schemaContent = await fs.readFile("src/schema.zed", "utf-8");
+
+        // Write schema to SpiceDB
+        const loaded = await client.writeSchema({
+            schema: schemaContent
+        });
+        console.log(loaded);
+
+        console.log("✅ Schema loaded into SpiceDB");
+        //console.log(await PermissionOperations.lookup().subjectsWithAccessTo("process:89b1fc48-1fd1-4ba3-8686-cc1e13cb9ff3").ofType("user").withPermissions(["read"], client))
+    } catch (error) {
+        console.error("❌ Failed to load schema:", error);
+    }
+}
+
+// Run the init function
+loadSchema().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+});

--- a/packages/authz/script/test.ts
+++ b/packages/authz/script/test.ts
@@ -1,0 +1,54 @@
+export const name = "authz";
+
+import { PermissionOperations, SpiceDBClient } from "@schoolai/spicedb-zed-schema-parser/builder";
+const SPICEDB_URL = process.env.SPICEDB_URL || 'localhost:8081';
+const SPICEDB_TOKEN = process.env.SPICEDB_TOKEN || 'localkey';
+
+import { v1 as authzed } from "@authzed/authzed-node";
+import fs from "node:fs/promises";
+import { permissions } from "../src/permissions.js";
+
+// Create client for local development
+const { promises: authzedClient } = authzed.NewClient(SPICEDB_TOKEN, SPICEDB_URL, 1);
+const client = authzedClient as unknown as SpiceDBClient;
+
+const op = PermissionOperations.lookup().subjectsWithAccessTo("project:1").ofType("user")
+
+// Function to load schema into SpiceDB
+async function loadSchema() {
+    console.log("Loading schema...");
+    try {
+        const schemaContent = await fs.readFile("src/schema.zed", "utf-8");
+
+        // Write schema to SpiceDB
+        await client.writeSchema({
+            schema: schemaContent
+        });
+
+        console.log("✅ Schema loaded into SpiceDB");
+    } catch (error) {
+        console.error("❌ Failed to load schema:", error);
+    }
+}
+
+// Function to test permissions
+async function testPermissions() {
+    try {
+        // First, grant some permissions
+        await permissions.project.grant.editor("user:alice", "project:1").execute(client);
+        console.log("✅ Granted editor permission to alice on document:1");
+
+        // Then check permissions
+        const canEdit = await permissions.project.check.edit("user:alice", "project:1").execute(client);
+        console.log("✅ Permission check result:", canEdit);
+
+    } catch (error) {
+        console.error("❌ Permission test failed:", error);
+    }
+}
+
+// Run the init function
+testPermissions().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+});

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -1,58 +1,14 @@
 export const name = "authz";
 
-import { PermissionOperations, SpiceDBClient } from "@schoolai/spicedb-zed-schema-parser/builder";
-const SPICEDB_URL = process.env.SPICEDB_URL || 'localhost:8081';
+import { SpiceDBClient } from "@schoolai/spicedb-zed-schema-parser/builder";
+const SPICEDB_URL = process.env.SPICEDB_URL || 'localhost:50051';
 const SPICEDB_TOKEN = process.env.SPICEDB_TOKEN || 'localkey';
 
-import { permissions } from "./permissions.js";
 import { v1 as authzed } from "@authzed/authzed-node";
-import fs from "node:fs/promises";
+import { permissions } from "./permissions";
 
 // Create client for local development
 const { promises: authzedClient } = authzed.NewClient(SPICEDB_TOKEN, SPICEDB_URL, 1);
 const client = authzedClient as unknown as SpiceDBClient;
 
-const op = PermissionOperations.lookup().subjectsWithAccessTo("project:1").ofType("user")
-
-// Function to load schema into SpiceDB
-async function loadSchema() {
-    console.log("Loading schema...");
-    try {
-        const schemaContent = await fs.readFile("src/schema.zed", "utf-8");
-
-        // Write schema to SpiceDB
-        await client.writeSchema({
-            schema: schemaContent
-        });
-
-        console.log("✅ Schema loaded into SpiceDB");
-    } catch (error) {
-        console.error("❌ Failed to load schema:", error);
-    }
-}
-
-// Function to test permissions
-async function testPermissions() {
-    try {
-        // First, grant some permissions
-        await permissions.project.grant.editor("user:alice", "project:1").execute(client);
-        console.log("✅ Granted editor permission to alice on document:1");
-
-        // Then check permissions
-        const canEdit = await permissions.project.check.edit("user:alice", "project:1").execute(client);
-        console.log("✅ Permission check result:", canEdit);
-
-    } catch (error) {
-        console.error("❌ Permission test failed:", error);
-    }
-}
-
-// Initialize and test
-async function init() {
-    console.log("Initializing...");
-    await loadSchema();
-    await testPermissions();
-}
-
-// Run the init function
-init().catch(console.error);
+export { permissions, client as spicedbClient };

--- a/packages/authz/src/permissions.ts
+++ b/packages/authz/src/permissions.ts
@@ -34,10 +34,10 @@ export const permissions = {
       viewer: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.revoke('viewer').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: OrganizationResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),
@@ -64,10 +64,10 @@ export const permissions = {
       organization: (subject: Subject<'organization'>, resource: TeamResource) => PermissionOperations.revoke('organization').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
       memberAccess: (subject: Subject<'user'>, resource: TeamResource) => PermissionOperations.check('member_access').subject(subject).resource(resource),
     },
     find: {
@@ -95,10 +95,10 @@ export const permissions = {
       organization: (subject: Subject<'organization'>, resource: ObjectiveResource) => PermissionOperations.revoke('organization').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: ObjectiveResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),
@@ -124,10 +124,10 @@ export const permissions = {
       objective: (subject: Subject<'objective'>, resource: KeyResultResource) => PermissionOperations.revoke('objective').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: KeyResultResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),
@@ -155,10 +155,10 @@ export const permissions = {
       keyResult: (subject: Subject<'key_result'>, resource: StrategyResource) => PermissionOperations.revoke('key_result').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: StrategyResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),
@@ -185,10 +185,10 @@ export const permissions = {
       organization: (subject: Subject<'organization'>, resource: ProcessResource) => PermissionOperations.revoke('organization').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: ProcessResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),
@@ -216,10 +216,10 @@ export const permissions = {
       team: (subject: Subject<'team'>, resource: ProjectResource) => PermissionOperations.revoke('team').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: ProjectResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),
@@ -246,10 +246,10 @@ export const permissions = {
       project: (subject: Subject<'project'>, resource: TaskResource) => PermissionOperations.revoke('project').subject(subject).resource(resource),
     },
     check: {
-      view: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('view').subject(subject).resource(resource),
-      edit: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('edit').subject(subject).resource(resource),
-      adminAccess: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('admin_access').subject(subject).resource(resource),
-      manage: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('manage').subject(subject).resource(resource),
+      create: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('create').subject(subject).resource(resource),
+      read: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('read').subject(subject).resource(resource),
+      update: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('update').subject(subject).resource(resource),
+      delete: (subject: Subject<'user'>, resource: TaskResource) => PermissionOperations.check('delete').subject(subject).resource(resource),
     },
     find: {
       byOwner: (subject: Subject<'user'>) => PermissionOperations.find().relation('owner').subject(subject),

--- a/packages/authz/src/schema.zed
+++ b/packages/authz/src/schema.zed
@@ -6,10 +6,10 @@ definition organization {
     relation editor: user
     relation viewer: user
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }
 
 definition team {
@@ -20,10 +20,10 @@ definition team {
     relation member: user
     relation organization: organization
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
     permission member_access = member + editor + admin + owner
 }
 
@@ -34,10 +34,10 @@ definition objective {
     relation viewer: user
     relation organization: organization
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }
 
 definition key_result {
@@ -47,10 +47,10 @@ definition key_result {
     relation viewer: user
     relation objective: objective
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }
 
 definition strategy {
@@ -61,10 +61,10 @@ definition strategy {
     relation organization: organization
     relation key_result: key_result
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }
 
 definition process {
@@ -74,10 +74,10 @@ definition process {
     relation viewer: user
     relation organization: organization
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }
 
 definition project {
@@ -88,10 +88,10 @@ definition project {
     relation organization: organization
     relation team: team
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }
 
 definition task {
@@ -101,8 +101,8 @@ definition task {
     relation viewer: user
     relation project: project
 
-    permission view = viewer + editor + admin + owner
-    permission edit = editor + admin + owner
-    permission admin_access = admin + owner
-    permission manage = owner
+    permission create = admin + owner
+    permission read = viewer + editor + admin + owner
+    permission update = editor + admin + owner
+    permission delete = owner
 }


### PR DESCRIPTION
This commit updates the permissions schema for the authz package.

The key changes are:

- ename the permissions to be more descriptive: `view` -> `read`, `edit`
  ;` -> `update`, `admin_access` -> `create`, `manage` -> `delete`.
- Simplify the permission assignments to use the new permission names.
- Add a new `loadSchema.ts` script to load the updated schema into SpiceDB.

These changes improve the clarity and consistency of the permissions model, making it easier to understand and use.