### PR TITLE
feat(organizations): add organization settings and members pages

### DIFF
--- a/apps/nextjs/src/app/(authenticatd)/create-organization/page.tsx
+++ b/apps/nextjs/src/app/(authenticatd)/create-organization/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+import { useTRPC } from "~/trpc/react";
+import { useMutation } from "@tanstack/react-query";
+import { authClient } from "~/auth/client";
+
+function slugify(name: string) {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .replace(/--+/g, "-");
+}
+
+export default function CreateOrganizationPage() {
+    const [name, setName] = useState("");
+    const [slug, setSlug] = useState("");
+    const [error, setError] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+    const router = useRouter();
+    const trpc = useTRPC();
+
+    const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newName = e.target.value;
+        setName(newName);
+        if (!slugManuallyEdited) {
+            setSlug(slugify(newName));
+        }
+    };
+
+    const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSlug(e.target.value);
+        setSlugManuallyEdited(true);
+    };
+
+    const handleSlugFocus = () => {
+        setSlugManuallyEdited(true);
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError("");
+        if (!name.trim() || !slug.trim()) {
+            setError("Name and slug are required.");
+            return;
+        }
+        setLoading(true);
+        const org = await authClient.organization.create({
+            name,
+            slug,
+            keepCurrentActiveOrganization: false,
+        })
+
+        setLoading(false);
+
+    };
+
+    return (
+        <div className="flex items-center justify-center bg-background">
+            <Card className="w-full max-w-md">
+                <CardHeader>
+                    <CardTitle>Create Organization</CardTitle>
+                </CardHeader>
+                <form onSubmit={handleSubmit} autoComplete="off">
+                    <CardContent className="space-y-5">
+                        <div className="space-y-2">
+                            <Label htmlFor="org-name">Organization Name</Label>
+                            <Input
+                                id="org-name"
+                                value={name}
+                                onChange={handleNameChange}
+                                placeholder="Acme Inc."
+                                autoFocus
+                            />
+                        </div>
+                        <div className="space-y-1">
+                            <Label htmlFor="org-slug">Slug</Label>
+                            <Input
+                                id="org-slug"
+                                value={slug}
+                                onChange={handleSlugChange}
+                                onFocus={handleSlugFocus}
+                                placeholder="acme"
+                            />
+                            <span className="text-xs text-muted-foreground">Short, unique ID for your organization (e.g. acme)</span>
+                        </div>
+                    </CardContent>
+                    <CardFooter className="flex flex-col gap-2">
+                        <Button type="submit" size="lg" className="w-full" disabled={loading}>
+                            {loading ? "Creating..." : "Create Organization"}
+                        </Button>
+                        {error && <div className="text-destructive text-sm text-center mt-1">{error}</div>}
+                    </CardFooter>
+                </form>
+            </Card>
+        </div>
+    );
+} 

--- a/apps/nextjs/src/app/(authenticatd)/organizations/settings/page.tsx
+++ b/apps/nextjs/src/app/(authenticatd)/organizations/settings/page.tsx
@@ -1,0 +1,14 @@
+import { OrganizationMembersCard, OrganizationSettingsCards } from '@daveyplate/better-auth-ui'
+import React from 'react'
+
+function Page() {
+    return (
+        <div className="container mx-auto space-y-6 p-6">
+            <OrganizationSettingsCards />
+            <OrganizationMembersCard />
+
+        </div>
+    )
+}
+
+export default Page

--- a/apps/nextjs/src/app/(authenticatd)/settings/page.tsx
+++ b/apps/nextjs/src/app/(authenticatd)/settings/page.tsx
@@ -1,0 +1,14 @@
+import { AccountSettingsCards, SecuritySettingsCards } from '@daveyplate/better-auth-ui'
+import React from 'react'
+
+function Page() {
+    return (
+        <div className="container mx-auto space-y-6 p-6">
+            <AccountSettingsCards />
+            <SecuritySettingsCards />
+
+        </div>
+    )
+}
+
+export default Page

--- a/apps/nextjs/src/app/_components/header.tsx
+++ b/apps/nextjs/src/app/_components/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { BookOpenIcon, InfoIcon, LifeBuoyIcon } from "lucide-react";
+import { BookOpenIcon, InfoIcon, LifeBuoyIcon, SettingsIcon } from "lucide-react";
 
 import Logo from "~/app/_components/logo";
 import { ModeToggle } from "~/app/_components/mode-toggle";
@@ -22,6 +22,7 @@ import {
 } from "~/components/ui/popover";
 import { cn } from "~/lib/utils";
 import { env } from "~/env";
+import { UserAvatar, UserButton } from "@daveyplate/better-auth-ui";
 
 // Navigation links array to be used in both desktop and mobile menus
 const navigationLinks = [
@@ -395,7 +396,21 @@ export default function Header() {
             </NavigationMenu>
           )}
           <ModeToggle />
-          <UserMenu />
+          <UserButton
+            size="icon"
+            localization={{
+              SETTINGS: "Account Settings",
+            }}
+            additionalLinks={[
+              {
+                href: "/organizations/settings",
+                label: "Organization Settings",
+                icon: <SettingsIcon />,
+                signedIn: true,
+                separator: true,
+              }
+            ]}
+          />
         </div>
       </div>
     </header>

--- a/apps/nextjs/src/app/providers.tsx
+++ b/apps/nextjs/src/app/providers.tsx
@@ -25,6 +25,10 @@ export function Providers({ children }: { children: ReactNode }) {
                         router.refresh()
                     }}
                     Link={Link}
+                    organization={{}}
+                    settings={{
+                        url: "/settings",
+                    }}
                 >
                     {children}
                 </AuthUIProvider>

--- a/apps/nextjs/src/auth/client.ts
+++ b/apps/nextjs/src/auth/client.ts
@@ -1,3 +1,9 @@
 import { createAuthClient } from "better-auth/react";
+import { organizationClient } from "better-auth/client/plugins"
 
-export const authClient = createAuthClient();
+
+export const authClient = createAuthClient({
+    plugins: [
+        organizationClient()
+    ]
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,6 +5,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { oAuthProxy, organization } from "better-auth/plugins";
 
 import { db } from "@acme/db/client";
+import { permissions, spicedbClient } from "@acme/authz";
 
 export function initAuth(options: {
   baseUrl: string;
@@ -33,6 +34,14 @@ export function initAuth(options: {
         teams: {
           enabled: true,
         },
+        organizationCreation: {
+          afterCreate: async ({ organization, member }) => {
+            await permissions.organization.grant.owner(
+              `user:${member.userId}`,
+              `organization:${organization.id}`
+            ).execute(spicedbClient);
+          }
+        }
       }),
     ],
     socialProviders: {

--- a/packages/db/src/auth-schema.ts
+++ b/packages/db/src/auth-schema.ts
@@ -68,16 +68,16 @@ export const verification = pgTable("verification", {
 });
 
 export const organization = pgTable("organization", {
-  id: text("id").primaryKey(),
+  id: text("id").$defaultFn(() => crypto.randomUUID()).primaryKey(),
   name: text("name").notNull(),
   slug: text("slug").unique(),
   logo: text("logo"),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
   metadata: text("metadata"),
 });
 
 export const member = pgTable("member", {
-  id: text("id").primaryKey(),
+  id: text("id").$defaultFn(() => crypto.randomUUID()).primaryKey(),
   organizationId: text("organization_id")
     .notNull()
     .references(() => organization.id, { onDelete: "cascade" }),
@@ -86,7 +86,7 @@ export const member = pgTable("member", {
     .references(() => user.id, { onDelete: "cascade" }),
   role: text("role").default("member").notNull(),
   teamId: text("team_id"),
-  createdAt: timestamp("created_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
 export const invitation = pgTable("invitation", {


### PR DESCRIPTION
This commit adds the organization settings and members pages to the 
application. The changes include:

- Added the `OrganizationSettingsCards` and `OrganizationMembersCard` components to the organization settings page.
- Added the `AccountSettingsCards` and `SecuritySettingsCards` components to the user settings page.
- Updated the `UserButton` component in the header to include a link to the organization settings page.
- Added the `organizationClient` plugin to the `authClient` instance to enable organization-related functionality.
- Updated the database schema to generate random UUIDs for organization and member IDs, and set default values for the `createdAt` timestamps.

These changes provide a more comprehensive set of settings and management options for organizations and users, improving the overall user experience.