### PR TITLE
feat(api): Simplify tRPC caller creation and remove unused code

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,4 @@
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
-import { headers } from "next/headers";
-import type { Auth } from "@acme/auth";
 
 import type { AppRouter } from "./root";
 import { appRouter } from "./root";
@@ -21,24 +19,6 @@ type RouterInputs = inferRouterInputs<AppRouter>;
  *      ^? Post[]
  **/
 type RouterOutputs = inferRouterOutputs<AppRouter>;
-
-/**
- * Helper function to create a tRPC caller for server-side usage
- * @example
- * const caller = await createCaller(auth)
- * const tasks = await caller.task.list()
- */
-export async function createCaller(auth: Auth) {
-    const heads = await headers();
-    //heads.set("x-trpc-source", "rsc");
-
-    const ctx = await createTRPCContext({
-        headers: heads,
-        auth,
-    });
-
-    return appRouter.createCaller(ctx);
-}
 
 export { createTRPCContext, appRouter };
 export type { AppRouter, RouterInputs, RouterOutputs };


### PR DESCRIPTION
The changes in this commit simplify the creation of a tRPC caller by 
removing the `createCaller` function and the associated code that was 
handling the headers and authentication. This reduces the complexity of 
the API code and makes it easier to use the tRPC functionality.

The changes also remove the unused imports and code related to the `headers` function from the Next.js framework, as it is no longer needed.