### PR TITLE
feat(api): Add authorization module dependency

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@acme/auth": "workspace:*",
+    "@acme/authz": "workspace:*",
     "@acme/db": "workspace:*",
     "@acme/validators": "workspace:*",
-    "@acme/authz": "workspace:*",
     "@trpc/server": "catalog:",
     "dotenv": "^16.4.5",
     "superjson": "2.2.2",


### PR DESCRIPTION
Adds the `@acme/authz` module as a dependency to the API package.
This is necessary to enable authorization functionality in the API.